### PR TITLE
Add list sharing OpenAPI documentation

### DIFF
--- a/docs/components/schemas/ListShare.yaml
+++ b/docs/components/schemas/ListShare.yaml
@@ -1,0 +1,31 @@
+type: object
+properties:
+  id:
+    type: integer
+    example: 1
+  listId:
+    type: integer
+    example: 1
+  sharedWithUserId:
+    type: integer
+    example: 2
+  permissionLevel:
+    type: string
+    enum: [VIEW, EDIT]
+    example: VIEW
+  createdAt:
+    type: string
+    format: date-time
+  updatedAt:
+    type: string
+    format: date-time
+  sharedWithUser:
+    type: object
+    properties:
+      id:
+        type: integer
+      username:
+        type: string
+      email:
+        type: string
+required: [id, listId, sharedWithUserId, permissionLevel]

--- a/docs/components/schemas/ListShareCreateRequest.yaml
+++ b/docs/components/schemas/ListShareCreateRequest.yaml
@@ -1,0 +1,11 @@
+type: object
+properties:
+  sharedWithUserId:
+    type: integer
+    example: 2
+  permissionLevel:
+    type: string
+    enum: [VIEW, EDIT]
+    default: VIEW
+    example: VIEW
+required: [sharedWithUserId]

--- a/docs/components/schemas/ListShareUpdateRequest.yaml
+++ b/docs/components/schemas/ListShareUpdateRequest.yaml
@@ -1,0 +1,7 @@
+type: object
+properties:
+  permissionLevel:
+    type: string
+    enum: [VIEW, EDIT]
+    example: EDIT
+required: [permissionLevel]

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -46,6 +46,15 @@ components:
     ListCreateRequest:
       $ref: ./components/schemas/ListCreateRequest.yaml
 
+    ListShare:
+      $ref: ./components/schemas/ListShare.yaml
+
+    ListShareCreateRequest:
+      $ref: ./components/schemas/ListShareCreateRequest.yaml
+
+    ListShareUpdateRequest:
+      $ref: ./components/schemas/ListShareUpdateRequest.yaml
+
     NotFoundError:
       $ref: ./components/schemas/NotFoundError.yaml
 
@@ -80,3 +89,9 @@ paths:
     $ref: paths/items_{id}.yaml
   /users/{id}:
     $ref: paths/users_{id}.yaml
+  /shares/shared-with-me:
+    $ref: paths/shares_shared-with-me.yaml
+  /shares/lists/{listId}/shares:
+    $ref: paths/shares_lists_{listId}_shares.yaml
+  /shares/lists/{listId}/shares/{shareId}:
+    $ref: paths/shares_lists_{listId}_shares_{shareId}.yaml

--- a/docs/paths/shares_lists_{listId}_shares.yaml
+++ b/docs/paths/shares_lists_{listId}_shares.yaml
@@ -1,0 +1,104 @@
+get:
+  summary: Get all users a list is shared with
+  tags: [List Sharing]
+  security:
+    - bearerAuth: []
+  parameters:
+    - name: listId
+      in: path
+      required: true
+      schema:
+        type: integer
+      description: List ID
+  responses:
+    '200':
+      description: List of shares
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: ../components/schemas/ListShare.yaml
+    '400':
+      description: Invalid ID format
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/ValidationError.yaml
+    '401':
+      description: Missing or invalid token
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/UnauthorizedError.yaml
+    '403':
+      description: Not the list owner
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/ForbiddenError.yaml
+    '404':
+      description: List not found
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/NotFoundError.yaml
+
+post:
+  summary: Share a list with another user
+  tags: [List Sharing]
+  security:
+    - bearerAuth: []
+  parameters:
+    - name: listId
+      in: path
+      required: true
+      schema:
+        type: integer
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../components/schemas/ListShareCreateRequest.yaml
+  responses:
+    '201':
+      description: List shared successfully
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/ListShare.yaml
+    '400':
+      description: Validation error
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/ValidationError.yaml
+    '401':
+      description: Missing or invalid token
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/UnauthorizedError.yaml
+    '403':
+      description: Not the list owner
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/ForbiddenError.yaml
+    '404':
+      description: List or user not found
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/NotFoundError.yaml
+    '409':
+      description: List already shared with this user
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                example: List is already shared with this user

--- a/docs/paths/shares_lists_{listId}_shares_{shareId}.yaml
+++ b/docs/paths/shares_lists_{listId}_shares_{shareId}.yaml
@@ -1,0 +1,97 @@
+put:
+  summary: Update share permission
+  tags: [List Sharing]
+  security:
+    - bearerAuth: []
+  parameters:
+    - name: listId
+      in: path
+      required: true
+      schema:
+        type: integer
+    - name: shareId
+      in: path
+      required: true
+      schema:
+        type: integer
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../components/schemas/ListShareUpdateRequest.yaml
+  responses:
+    '200':
+      description: Share updated successfully
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/ListShare.yaml
+    '400':
+      description: Validation error
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/ValidationError.yaml
+    '401':
+      description: Missing or invalid token
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/UnauthorizedError.yaml
+    '403':
+      description: Not the list owner
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/ForbiddenError.yaml
+    '404':
+      description: Share not found
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/NotFoundError.yaml
+
+delete:
+  summary: Remove a share
+  tags: [List Sharing]
+  security:
+    - bearerAuth: []
+  parameters:
+    - name: listId
+      in: path
+      required: true
+      schema:
+        type: integer
+    - name: shareId
+      in: path
+      required: true
+      schema:
+        type: integer
+  responses:
+    '204':
+      description: Share removed successfully
+    '400':
+      description: Invalid ID format
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/ValidationError.yaml
+    '401':
+      description: Missing or invalid token
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/UnauthorizedError.yaml
+    '403':
+      description: Not the list owner
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/ForbiddenError.yaml
+    '404':
+      description: Share not found
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/NotFoundError.yaml

--- a/docs/paths/shares_shared-with-me.yaml
+++ b/docs/paths/shares_shared-with-me.yaml
@@ -1,0 +1,30 @@
+get:
+  summary: Get all lists shared with the current user
+  tags: [List Sharing]
+  security:
+    - bearerAuth: []
+  responses:
+    '200':
+      description: Lists shared with user
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              type: object
+              properties:
+                id:
+                  type: integer
+                listId:
+                  type: integer
+                permissionLevel:
+                  type: string
+                  enum: [VIEW, EDIT]
+                list:
+                  $ref: ../components/schemas/List.yaml
+    '401':
+      description: Missing or invalid token
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/UnauthorizedError.yaml

--- a/src/server.js
+++ b/src/server.js
@@ -1,13 +1,15 @@
 import express from 'express';
 import morgan from 'morgan';
+import cors from 'cors';
+import swaggerUi from 'swagger-ui-express';
+import YAML from 'yamljs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 const swaggerDocument = YAML.load(join(__dirname, '../docs/openapi.yaml'));
-
-import cors from 'cors';
-import swaggerUi from 'swagger-ui-express';
-import YAML from 'yamljs';
 import authRoutes from './routes/authRoutes.js';
 import listRoutes from './routes/listRoutes.js';
 import categoryRoutes from './routes/categoryRoutes.js';


### PR DESCRIPTION
## List Sharing OpenAPI Documentation

Added complete API documentation for all list sharing endpoints in the split YAML structure.

### Files Added:
**Schemas:**
- `docs/components/schemas/ListShare.yaml`
- `docs/components/schemas/ListShareCreateRequest.yaml`
- `docs/components/schemas/ListShareUpdateRequest.yaml`

**Paths:**
- `docs/paths/shares_shared-with-me.yaml`
- `docs/paths/shares_lists_{listId}_shares.yaml`
- `docs/paths/shares_lists_{listId}_shares_{shareId}.yaml`

### Files Modified:
- `docs/openapi.yaml` - Added references to new schemas and paths
- `src/server.js` - Fixed missing imports for Swagger setup

### Endpoints Documented:
- `GET /shares/shared-with-me` - View lists shared with current user
- `GET /shares/lists/{listId}/shares` - View who has access to a list
- `POST /shares/lists/{listId}/shares` - Share list with another user
- `PUT /shares/lists/{listId}/shares/{shareId}` - Update permission level
- `DELETE /shares/lists/{listId}/shares/{shareId}` - Revoke access

All list sharing endpoints now appear in Swagger UI at `/api-docs` under the "List Sharing" tag.